### PR TITLE
Актуализация скриптов GitHub Actions

### DIFF
--- a/.github/workflows/CI-posix.yml
+++ b/.github/workflows/CI-posix.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: Bootstrapping on ${{ matrix.os }} with ${{ matrix.ccomp }}
         run: |
@@ -34,7 +34,7 @@ jobs:
           ./bootstrap.sh
         shell: bash
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: log-info-posix-${{ matrix.os }}-${{ matrix.ccomp }}

--- a/.github/workflows/CI-windows.yml
+++ b/.github/workflows/CI-windows.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: Bootstrapping with ${{ matrix.ccomp }}
         run: |
@@ -25,7 +25,7 @@ jobs:
           bootstrap.bat
         shell: cmd
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: log-info-windows-${{ matrix.ccomp }}

--- a/.github/workflows/conf-template-msvc32.bat
+++ b/.github/workflows/conf-template-msvc32.bat
@@ -1,6 +1,6 @@
 @echo off
 
-call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars32.bat"
+call "C:\Program Files\Microsoft Visual Studio\18\Enterprise\VC\Auxiliary\Build\vcvars32.bat"
 set CPPLINEE=cl /O1 /EHcs /W3 /wd4996 /Fe
 set CPPLINEESUF=
 set CPPLINEL=cl /EHcs /W3 /wd4996 /LD /Fe

--- a/.github/workflows/conf-template-msvc64.bat
+++ b/.github/workflows/conf-template-msvc64.bat
@@ -1,6 +1,6 @@
 @echo off
 
-call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+call "C:\Program Files\Microsoft Visual Studio\18\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
 set CPPLINEE=cl /O1 /EHcs /W3 /wd4996 /Fe
 set CPPLINEESUF=
 set CPPLINEL=cl /EHcs /W3 /wd4996 /LD /Fe


### PR DESCRIPTION
* `actions/checkout@v3` → `actions/checkout@v6`
* `actions/upload-artifact@v4` → `actions/upload-artifact@v7`
* `…\Microsoft Visual Studio\2022\Enterprise\…` → `…\Microsoft Visual Studio\18\Enterprise\…`

На `checkout@v3` выдавалось предупреждение:

<img width="528" height="232" alt="image" src="https://github.com/user-attachments/assets/c52d7c58-bd47-4077-accd-7eb3a3b4add2" />

Поднял номер версии заодно и у `upload-artifact`.